### PR TITLE
Support typescript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,2 @@
+declare function router(options: any) :any
+export default router;


### PR DESCRIPTION
Currently,  if import this module into a `typescript` project, it will message:
```
Could not find a declaration file for module 'nnn-router'. 
'/root/project/evaluation-api-ts/node_modules/nnn-router/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/nnn-router` if it exists or add a new declaration (.d.ts) file containing
   `declare module 'nnn-router';
```
This file will declare module with typescript language.
